### PR TITLE
Remove assets definition from cloud native basics course

### DIFF
--- a/intro-to-containers-k8s/index.json
+++ b/intro-to-containers-k8s/index.json
@@ -88,9 +88,6 @@
       "text": "finish.md"
     }
   },
-  "assets": {
-    "host01": []
-  },
   "environment": {
     "icon": "fa-kubernetes",
     "showdashboard": true,


### PR DESCRIPTION
An empty assets array in index.json throws an error in the interface
This isn't even used in this scenario so removing it will resolve
the error